### PR TITLE
Fix vue warnings and other cleanup

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -1,33 +1,33 @@
 <template>
-  <tr class="component-tr" v-bind:class="{ ['has-error']: !isloaded }">
+  <tr class="component-tr" :class="{ 'has-error': !isloaded }">
 	<td class="name-column">{{se_component.name}}</td>
 
-	<td class="quantity-column" v-bind:class="{ ['has-error']: has_quantity_error }">
+	<td class="quantity-column" :class="{ 'has-error': has_quantity_error }">
 	  <select
 		v-if="quantity_configurable"
 		class="quantity-column-select"
 		v-model="quantity"
 		v-on:wheel="quantity_select_wheel_event"
-		v-bind:class="{ ['has-error']: has_quantity_error }">
+		:class="{ 'has-error': has_quantity_error }">
 
 		<option v-if="!valid_quantities.includes(quantity)">{{quantity}}</option>
-		<option v-for="valid_quantity in valid_quantities">{{valid_quantity}}</option>
+		<option v-for="valid_quantity in valid_quantities" :key="valid_quantity">{{valid_quantity}}</option>
 	  </select>
 	  <span v-if="!quantity_configurable">{{quantity_pretty}}</span>
 	</td>
 
-	<td class="part-column" v-bind:class="part_column_select_computed">
+	<td class="part-column" :class="part_column_select_computed">
 	  <select
 		v-model="part"
-		v-bind:class="part_column_select_computed"
+		:class="part_column_select_computed"
 		class="part-column-select">
-		<option v-for="part_value in valid_parts">{{part_value['Name']}}</option>
+		<option v-for="part_value in valid_parts" :key="part_value['Name']">{{part_value['Name']}}</option>
 		<option v-if="!is_valid_part">{{part}}</option>
 	  </select>
 	</td>
 
 	<template v-for="name in stats.names">
-	  <StatlineCell :stats="stats" :name="name"></StatlineCell>
+	  <StatlineCell :key="name" :stats="stats" :name="name"></StatlineCell>
 	</template>
 
 	<td class="weight-internal-column">{{weight_internal}}</td>
@@ -40,14 +40,14 @@
 	<td class="power-gen-column">{{power_gen}}</td>
 
 	<template v-for="name in crew.names">
-	  <StatlineCell :stats="crew" :name="name"></StatlineCell>
+	  <StatlineCell :key="name" :stats="crew" :name="name"></StatlineCell>
 	</template>
 
 	<td class="build-time-column"></td>
 
 	<td class="tech-year-column"
-		v-bind:class="{ ['has-warning']: is_limiting_tech_year }"
-		v-bind:title="tech_year_tooltip"
+		:class="{ ['has-warning']: is_limiting_tech_year }"
+		:title="tech_year_tooltip"
 		>{{tech_year}}</td>
   </tr>
 </template>
@@ -87,7 +87,7 @@ export default {
 		},
 		part_column_select_computed () {
 			return {
-				['has-error']: !this.is_valid_part,
+				'has-error': !this.is_valid_part,
 			};
 		},
 		is_valid_part () {

--- a/src/csvimporter.vue
+++ b/src/csvimporter.vue
@@ -17,7 +17,7 @@
 
   	<div>
   	  <span>Parts list name:</span>
-  	  <input v-model="name_computed"></input>
+  	  <input v-model="name_computed"/>
   	</div>
 	
   	<div>
@@ -26,7 +26,7 @@
   		type="file"
   		ref="load_parts_file_input"
   		@change="load_file_parts"
-  		value="Load parts csv"></input>
+  		value="Load parts csv"/>
   	</div>
 
   	<div>
@@ -35,7 +35,7 @@
   		type="file"
   		ref="load_frames_file_input"
   		@change="load_file_frames"
-  		value="Load frames csv"></input>
+  		value="Load frames csv"/>
   	</div>
 
   	<div>
@@ -44,14 +44,14 @@
   		type="file"
   		ref="load_modules_file_input"
   		@change="load_file_modules"
-  		value="Load modules csv"></input>
+  		value="Load modules csv"/>
   	</div>
 
   	<div v-if="can_import">
   	  <input
   		type="button"
   		@click="import_parts_list"
-  		value="Import parts list"></input>
+  		value="Import parts list"/>
   	</div>
 
 	<div v-if="success">
@@ -63,22 +63,22 @@
   	  <ul>
   		<li v-if="has_name_errors">Name:
   		  <ol>
-  			<li v-for="er in name_error_messages">{{er}}</li>
+  			<li v-for="(er, index) in name_error_messages" :key="index">{{er}}</li>
   		  </ol>
   		</li>
   		<li v-if="has_parts_errors">Parts file:
   		  <ol>
-  			<li v-for="er in parts_error_messages">{{er}}</li>
+  			<li v-for="(er, index) in parts_error_messages" :key="index">{{er}}</li>
   		  </ol>
   		</li>
   		<li v-if="has_frames_errors">Frames file:
   		  <ol>
-  			<li v-for="er in frames_error_messages">{{er}}</li>
+  			<li v-for="(er, index) in frames_error_messages" :key="index">{{er}}</li>
   		  </ol>
   		</li>
   		<li v-if="has_modules_errors">Modules file:
   		  <ol>
-  			<li v-for="er in modules_error_messages">{{er}}</li>
+  			<li v-for="(er, index) in modules_error_messages" :key="index">{{er}}</li>
   		  </ol>
   		</li>
   	  </ul>

--- a/src/design-import-export.vue
+++ b/src/design-import-export.vue
@@ -3,33 +3,33 @@
 	<input type="button"
 		   class="undo-button"
 		   @click="dispatch_undo"
-		   value="<"></input>
+		   value="<"/>
 	<input type="button"
 		   class="redo-button"
 		   @click="dispatch_redo"
-		   value=">"></input>
+		   value=">"/>
 
     <select v-model="selected_parts_list_name">
-      <option v-for="parts_list in all_parts_lists">
+      <option v-for="parts_list in all_parts_lists" :key="parts_list.pretty_name">
 		{{parts_list.pretty_name}}
       </option>
     </select>
 
-    <input type="button" @click="parts_lists_load_selected" value="Load parts list"></input>
+    <input type="button" @click="parts_lists_load_selected" value="Load parts list"/>
 
-	<span><a v-bind:href="'shipdesigner.html#' + design_json_url_encoded_string">Link to this design</a></span>
+	<span><a :href="'shipdesigner.html#' + design_json_url_encoded_string">Link to this design</a></span>
 
     <select v-model="selected_design_name">
-      <option v-for="blueprint in local_saves">
+      <option v-for="blueprint in local_saves" :key="blueprint.pretty_name">
 		{{blueprint.pretty_name}}
       </option>
     </select>
 
-    <input type="button" @click="local_saves_delete_selected" value="Delete save"></input>
-    <input type="button" @click="local_saves_load_selected" value="Load save"></input>
+    <input type="button" @click="local_saves_delete_selected" value="Delete save"/>
+    <input type="button" @click="local_saves_load_selected" value="Load save"/>
 
-    <input type="button" @click="local_saves_save_design" value="Save current design"></input>
-    <input type="button" @click="local_saves_load_from_local_storage" value="Refresh"></input>
+    <input type="button" @click="local_saves_save_design" value="Save current design"/>
+    <input type="button" @click="local_saves_load_from_local_storage" value="Refresh"/>
 
     <span
 	  ref="status_message"

--- a/src/design-summary.vue
+++ b/src/design-summary.vue
@@ -4,11 +4,11 @@
 	  <span>{{se_design.name}} | {{se_design.pretty_miscstats}}</span>
 	  <span> | </span>
 	  <span
-		v-bind:class="{['has-error']: has_parts_list_load_error}"
-		v-bind:title="parts_list_load_title">Parts: {{parts_list_name}}</span>
+		:class="{'has-error': has_parts_list_load_error}"
+		:title="parts_list_load_title">Parts: {{parts_list_name}}</span>
 	  <span
 		v-if="has_parts_list_load_error"
-		v-bind:class="{['has-error']: has_parts_list_load_error}"> (WRONG PARTS LIST! EVERYTHING MAY BE INVALID!)</span>
+		:class="{'has-error': has_parts_list_load_error}"> (WRONG PARTS LIST! EVERYTHING MAY BE INVALID!)</span>
 	</div>
 
 	<div>
@@ -24,16 +24,17 @@
 	<div>
 	  <span
 		class="design-power-summary"
-		v-bind:class="{['has-error']: se_design.cost_power > se_design.power_generation}"
+		:class="{'has-error': se_design.cost_power > se_design.power_generation}"
 		>Power[{{se_design.cost_power_raw.toFixed(2)}}/{{se_design.power_generation_raw.toFixed(2)}}]</span>
 	  <span
 		class="design-weight-summary"
-		v-bind:class="{['has-error']: se_design.weight_internal > se_design.frame_max_size_raw}"
+		:class="{'has-error': se_design.weight_internal > se_design.frame_max_size_raw}"
 		>Internal[{{se_design.weight_internal.toFixed(2)}}/{{se_design.frame_max_size_raw.toFixed(2)}}]</span>
 	  <span
 		class="subsystem-weight-summary"
 		v-for="ss in se_design.subsystems"
-		v-bind:class="{['has-error']: ss.weight_internal > ss.weight_cap}"
+		:key="ss.name"
+		:class="{'has-error': ss.weight_internal > ss.weight_cap}"
 		>{{ss.name}}[{{ss.weight_internal.toFixed(2)}}/{{ss.weight_cap.toFixed(2)}}] </span>
 	</div>
   </div>

--- a/src/design.vue
+++ b/src/design.vue
@@ -29,13 +29,13 @@
 		<PrincipalFrameFinal></PrincipalFrameFinal>
 		<PrincipalFrameRaw></PrincipalFrameRaw>
 		<template v-for="se_subsystem in se_subsystems">
-		  <tr class="subsystem-spacer-row"><td colspan="100" height="30px"></td></tr>	<!-- empty line for spacing -->
-		  <SubsystemFrame :se_subsystem="se_subsystem"></SubsystemFrame>
-		  <SubsystemSummary :se_subsystem="se_subsystem"></SubsystemSummary>
-		  <SubsystemSettings :se_subsystem="se_subsystem"></SubsystemSettings>
+		  <tr :key="se_subsystem.name" class="subsystem-spacer-row"><td colspan="100" height="30px"></td></tr>	<!-- empty line for spacing -->
+		  <SubsystemFrame :key="se_subsystem.name + '-frame'" :se_subsystem="se_subsystem"></SubsystemFrame>
+		  <SubsystemSummary :key="se_subsystem.name + '-summary'" :se_subsystem="se_subsystem"></SubsystemSummary>
+		  <SubsystemSettings :key="se_subsystem.name + '-settings'" :se_subsystem="se_subsystem"></SubsystemSettings>
 
 		  <template v-for="se_component in se_subsystem.components">
-			<ComponentTr :se_component="se_component"></ComponentTr>
+			<ComponentTr :key="se_component.name" :se_component="se_component"></ComponentTr>
 		  </template>
 		</template>
 

--- a/src/module.vue
+++ b/src/module.vue
@@ -1,20 +1,20 @@
 <template>
-  <tr class="module-tr" v-bind:class="{ hasloaderror: !isloaded }">
+  <tr class="module-tr" :class="{ hasloaderror: !isloaded }">
 	<td class="name-column" colspan="2">Module</td>
 
 	<td class="part-column">
 	  <span class="module-pair-span">
 		<span class="module-pair-type"><select v-model="module_type" class="part-column-select">
-			<option v-for="module_type_value in valid_types">{{module_type_value}}</option>
+			<option v-for="module_type_value in valid_types" :key="module_type_value">{{module_type_value}}</option>
 		</select></span>
 		<span class="module-pair-variant"><select v-model="module_variant" class="part-column-select">
-			<option v-for="module_variant_value in valid_variants">{{module_variant_value['Variant']}}</option>
+			<option v-for="module_variant_value in valid_variants" :key="module_variant_value['Variant']">{{module_variant_value['Variant']}}</option>
 		</select></span>
 	  </span>
 	</td>
 
 	<template v-for="name in stats.names">
-	  <StatlineCell :stats="stats" :name="name"></StatlineCell>
+	  <StatlineCell :key="name" :stats="stats" :name="name"></StatlineCell>
 	</template>
 
 	<td class="weight-internal-column">{{weight_internal}}</td>
@@ -27,7 +27,7 @@
 	<td class="power-gen-column">{{power_gen}}</td>
 
 	<template v-for="name in crew.names">
-	  <StatlineCell :stats="crew" :name="name"></StatlineCell>
+	  <StatlineCell :key="name" :stats="crew" :name="name"></StatlineCell>
 	</template>
 
 	<td class="build-time-column">{{build_time}}</td>

--- a/src/partbuilder.vue
+++ b/src/partbuilder.vue
@@ -47,12 +47,14 @@ export default {
 			const saved_parts = localStorage.getItem(PARTS_KEY);
 			if (saved_parts) {
 				this.data = JSON.parse(saved_parts);
-			} else {
+			} else if (this.data) {
 				localStorage.setItem(PARTS_KEY, JSON.stringify(this.data));
 			};
 		},
 		save_parts_to_storage () {
-			localStorage.setItem(PARTS_KEY, JSON.stringify(this.data));
+			if (this.data) {
+				localStorage.setItem(PARTS_KEY, JSON.stringify(this.data));
+			}
 		},
 	},
 };

--- a/src/parts-list-cell.vue
+++ b/src/parts-list-cell.vue
@@ -3,7 +3,7 @@
 	  @click="edit_cell"
 	  @focus="edit_cell"
 	  tabindex="0"
-	  v-bind:style="computed_style">
+	  :style="computed_style">
 
 	<span
 	  class="display-span"
@@ -17,7 +17,7 @@
 	  @blur="commit_edit"
 	  @keydown="on_keydown"
 	  v-focus
-	  v-model="temp_value"></input>
+	  v-model="temp_value"/>
   </td>
 </template>
 

--- a/src/parts-list-editor.vue
+++ b/src/parts-list-editor.vue
@@ -3,13 +3,14 @@
   <table class="editor">
 	<thead>
 	  <th v-for="field in selected_schema"
+		  :key="field.name"
 		  @click="sort_list(field.name)"
 		  class="column-header"
-		  v-bind:style="header_style(field)">{{field.name}}</th>
+		  :style="header_style(field)">{{field.name}}</th>
 	  <th class="column-header delete-column"></th>
 	</thead>
 	<tbody>
-	  <PartsListPart v-for="part in displayed_parts" key="part.name" :part="part"></PartsListPart>
+	  <PartsListPart v-for="part in displayed_parts" :key="part.name" :part="part"></PartsListPart>
 	</tbody>
   </table>
   <input type="button" value="Add new part" @click="add_new_part" class="new-part-button">

--- a/src/parts-list-footer.vue
+++ b/src/parts-list-footer.vue
@@ -6,26 +6,26 @@
 	<input v-model="parts_list_name">
 
     <select v-model="selected_parts_list_name">
-      <option v-for="parts_list in all_parts_lists">
+      <option v-for="parts_list in all_parts_lists" :key="parts_list_save_name(parts_list)">
 		{{parts_list_save_name(parts_list)}}
       </option>
     </select>
 
-    <input type="button" @click="parts_lists_delete_selected" value="Delete saved parts"></input>
-    <input type="button" @click="parts_lists_load_selected" value="Load saved parts"></input>
+    <input type="button" @click="parts_lists_delete_selected" value="Delete saved parts"/>
+    <input type="button" @click="parts_lists_load_selected" value="Load saved parts"/>
 
-    <input type="button" @click="parts_lists_save_current" value="Save current parts"></input>
-    <input type="button" @click="parts_lists_load_from_local_storage" value="Refresh"></input>
+    <input type="button" @click="parts_lists_save_current" value="Save current parts"/>
+    <input type="button" @click="parts_lists_load_from_local_storage" value="Refresh"/>
 
-	<input type="button" @click="parts_lists_save_file" value="Save to file"></input>
-	<input type="button" @click="$refs.load_file_input.click()" value="Load from file"></input>
+	<input type="button" @click="parts_lists_save_file" value="Save to file"/>
+	<input type="button" @click="$refs.load_file_input.click()" value="Load from file"/>
 
     <input
 	  style="display:none"
 	  type="file"
 	  ref="load_file_input"
 	  @change="parts_lists_load_file"
-	  value="Load file"></input>
+	  value="Load file"/>
 
 	<a ref="save_file_a" style="display:none"></a>
 

--- a/src/parts-list-header.vue
+++ b/src/parts-list-header.vue
@@ -3,12 +3,13 @@
 	<div class="select-tab-column">
 	  <div class="select-tab"
 		   v-for="select in ['parts','modules','frames']"
+		   :key="select"
 		   @click="set_selection(select)"
-		   v-bind:class="tab_class_select(select)">
+		   :class="tab_class_select(select)">
 		<div class="select-tab-text">{{select}}</div>
 		<div class="indicator-lamp-wrapper">
 		  <div class="indicator-lamp-spacer"></div>
-		  <div class="indicator-lamp" v-bind:class="lamp_class_select(select)"></div>
+		  <div class="indicator-lamp" :class="lamp_class_select(select)"></div>
 		  <div class="indicator-lamp-spacer"></div>
 		</div>
 	  </div>
@@ -17,12 +18,13 @@
 	<div class="type-tab-column">
 	  <div class="type-tab"
 		   v-for="type in types"
+		   :key="type"
 		   @click="set_filter(type)"
-		   v-bind:class="tab_class_type(type)">
+		   :class="tab_class_type(type)">
 		<div class="type-tab-text">{{type}}</div>
 		<div class="indicator-lamp-wrapper">
 		  <div class="indicator-lamp-spacer"></div>
-		  <div class="indicator-lamp" v-bind:class="lamp_class_type(type)"></div>
+		  <div class="indicator-lamp" :class="lamp_class_type(type)"></div>
 		  <div class="indicator-lamp-spacer"></div>
 		</div>
 	  </div>

--- a/src/parts-list-part.vue
+++ b/src/parts-list-part.vue
@@ -2,7 +2,7 @@
   <tr class="part">
 	<PartsListCell
 	  v-for="field in selected_schema"
-	  v-bind:class="list_class(field)"
+	  :class="list_class(field)"
 	  :key="field.name"
 	  :part="part"
 	  :field="field">
@@ -37,7 +37,7 @@ export default {
 		list_class () {
 			return function (field) {
 				return {
-					['has-error']: (field.id === 'name') && (this.has_duplicate_name_error),
+					'has-error': (field.id === 'name') && (this.has_duplicate_name_error),
 				};
 			};
 		},

--- a/src/principal-frame-final.vue
+++ b/src/principal-frame-final.vue
@@ -7,7 +7,7 @@
 	<td class="part-column">{{principal_frame}}</td>
 
 	<template v-for="name in stats.names">
-	  <StatlineCell :stats="stats" :name="name" :fixed="0"></StatlineCell>
+	  <StatlineCell :key="name" :stats="stats" :name="name" :fixed="0"></StatlineCell>
 	</template>
 	
 	<td class="weight-internal-column" colspan="2">{{se_design.weight_total}}</td>
@@ -16,14 +16,14 @@
 	<td class="sr-column">{{se_design.cost_SR}}</td>
 
 	<td class="power-cost-column"
-		v-bind:title="power_final_title"
-		v-bind:class="power_final_class">{{se_design.cost_power}}</td>
+		:title="power_final_title"
+		:class="power_final_class">{{se_design.cost_power}}</td>
 	<td class="power-gen-column"
-		v-bind:title="power_final_title"
-		v-bind:class="power_final_class">{{se_design.power_generation}}</td>
+		:title="power_final_title"
+		:class="power_final_class">{{se_design.power_generation}}</td>
 
 	<template v-for="name in crew.names">
-	  <StatlineCell :stats="crew" :name="name" :fixed="0"></StatlineCell>
+	  <StatlineCell :key="name" :stats="crew" :name="name" :fixed="0"></StatlineCell>
 	</template>
 
 	<td class="build-time-column">{{build_time}}</td>
@@ -58,7 +58,7 @@ export default {
 		},
 		power_final_class () {
 			return {
-				['has-error']: this.has_power_error,
+				'has-error': this.has_power_error,
 			};
 		},
 		has_power_error () {

--- a/src/principal-frame-raw.vue
+++ b/src/principal-frame-raw.vue
@@ -4,15 +4,15 @@
 
 	<td class="part-column">
 	  <select v-model="principal_frame" class="part-column-select">
-		<option v-for="princ_frame_value in se_design.valid_frames">{{princ_frame_value['Name']}}</option>
+		<option v-for="princ_frame_value in se_design.valid_frames" :key="princ_frame_value['Name']">{{princ_frame_value['Name']}}</option>
 	  </select>
 	</td>
 
 	<template v-for="name in stats_raw.names">
-	  <StatlineCell :stats="stats_raw" :name="name"></StatlineCell>
+	  <StatlineCell :key="name" :stats="stats_raw" :name="name"></StatlineCell>
 	</template>
 	
-	<td class="weight-internal-column" v-bind:class="weight_summary_class">{{se_design.weight_internal.toFixed(2)}}</td>
+	<td class="weight-internal-column" :class="weight_summary_class">{{se_design.weight_internal.toFixed(2)}}</td>
 	<td class="weight-external-column">{{se_design.weight_external.toFixed(2)}}</td>
 
 	<td class="br-column">{{se_design.cost_BR_raw.toFixed(2)}}</td>
@@ -22,7 +22,7 @@
 	<td class="power-gen-column">{{se_design.power_generation_raw.toFixed(2)}}</td>
 
 	<template v-for="name in crew_raw.names">
-	  <StatlineCell :stats="crew_raw" :name="name"></StatlineCell>
+	  <StatlineCell :key="name" :stats="crew_raw" :name="name"></StatlineCell>
 	</template>
 
 	<td class="build-time-column">{{build_time_frame}}</td>
@@ -50,7 +50,7 @@ export default {
 	computed: {
 		weight_summary_class () {
 			return {
-				['has-error']: this.has_weight_error,
+				'has-error': this.has_weight_error,
 			};
 		},
 		has_weight_error () {

--- a/src/setting-cell.vue
+++ b/src/setting-cell.vue
@@ -7,7 +7,7 @@
 	  class="setting-input-number"
 	  type="number"
 	  v-model="setting_value">
-	  <option v-for="num in valid_numbers">{{num}}</option>
+	  <option v-for="num in valid_numbers" :key="num">{{num}}</option>
 	</select>
 
 	<input

--- a/src/subsystem-frame.vue
+++ b/src/subsystem-frame.vue
@@ -4,14 +4,14 @@
 	<td class="name-column" colspan="2">{{se_subsystem.name}}</td>
 
 	<td class="part-column">
-	  <select v-model="sub_frame" class="part-column-select" v-bind:class="part_column_select_computed">
-		<option v-for="sub_frame_value in se_subsystem.valid_frames">{{sub_frame_value['Name']}}</option>
+	  <select v-model="sub_frame" class="part-column-select" :class="part_column_select_computed">
+		<option v-for="sub_frame_value in se_subsystem.valid_frames" :key="sub_frame_value['Name']">{{sub_frame_value['Name']}}</option>
 		<option v-if="!is_valid_frame">{{sub_frame}}</option>
 	  </select>
 	</td>
 
 	<template v-for="name in stats.names">
-	  <td class="stat-column">{{stats_multiplier_pretty}}</td>
+	  <td :key="name" class="stat-column">{{stats_multiplier_pretty}}</td>
 	</template>
 
 	<td class="weight-internal-column" colspan="2">{{se_subsystem.weight_cap.toFixed(2)}}</td>
@@ -23,7 +23,7 @@
 	<td class="power-gen-column"></td>
 
 	<template v-for="name in crew.names">
-	  <StatlineCell :stats="crew_mult_pretty" :name="name" :ispretty="false"></StatlineCell>
+	  <StatlineCell :key="name" :stats="crew_mult_pretty" :name="name" :ispretty="false"></StatlineCell>
 	</template>
 
 	<td class="build-time-column">{{build_time}}</td>
@@ -56,7 +56,7 @@ export default {
 	computed: {
 		part_column_select_computed () {
 			return {
-				['has-error']: !this.is_valid_frame,
+				'has-error': !this.is_valid_frame,
 			};
 		},
 		is_valid_frame () {

--- a/src/subsystem-summary.vue
+++ b/src/subsystem-summary.vue
@@ -2,16 +2,16 @@
 
   <tr class="subsystem-summary">
 	<td class="name-column"
-		v-bind:class="weight_summary_class"
+		:class="weight_summary_class"
 		colspan="2">{{se_subsystem.weight_internal.toFixed(2)}}/{{se_subsystem.weight_cap.toFixed(2)}}</td>
 
 	<td class="part-column"></td>
 
 	<template v-for="name in stats.names">
-	  <StatlineCell :stats="stats" :name="name"></StatlineCell>
+	  <StatlineCell :key="name" :stats="stats" :name="name"></StatlineCell>
 	</template>
 
-	<td class="weight-internal-column" v-bind:class="weight_summary_class">{{se_subsystem.weight_internal.toFixed(2)}}</td>
+	<td class="weight-internal-column" :class="weight_summary_class">{{se_subsystem.weight_internal.toFixed(2)}}</td>
 	<td class="weight-external-column">{{se_subsystem.weight_external.toFixed(2)}}</td>
 
 	<td class="br-column">{{se_subsystem.cost_BR.toFixed(2)}}</td>
@@ -21,7 +21,7 @@
 	<td class="power-gen-column">{{se_subsystem.power_generation.toFixed(2)}}</td>
 
 	<template v-for="name in crew.names">
-	  <StatlineCell :stats="crew" :name="name"></StatlineCell>
+	  <StatlineCell :key="name" :stats="crew" :name="name"></StatlineCell>
 	</template>
 
 	<td class="build-time-column">{{build_time}}</td>
@@ -53,7 +53,7 @@ export default {
 	computed: {
 		weight_summary_class () {
 			return {
-				['has-error']: this.has_weight_error,
+				'has-error': this.has_weight_error,
 			};
 		},
 		has_weight_error () {


### PR DESCRIPTION
- Ensure v-for has corresponding :key's.
- v-bind's replaced with shorthand.
- Empty input tags made self-closing tags.
- Replace ['has-error'] with 'has-error'.
- Avoid saving 'undefined' working_parts_list in local storage.