### PR TITLE
Implement refit and compare design modes

### DIFF
--- a/src/components/shipdesigner/component.vue
+++ b/src/components/shipdesigner/component.vue
@@ -229,7 +229,7 @@ export default {
 }
 
 .compare-base-value {
-	background: #ffff00;
+	background: #aa80ff;
 }
 
 .has-error {

--- a/src/components/shipdesigner/component.vue
+++ b/src/components/shipdesigner/component.vue
@@ -2,7 +2,11 @@
 	<tr class="component-tr" :class="{ 'has-error': !is_loaded }">
 		<td class="name-column">{{se_component.name}}</td>
 
-		<td class="quantity-column" :class="{ 'has-error': has_quantity_error }">
+		<td :class="{
+				'quantity-column': true,
+				'has-error': has_quantity_error,
+				'compare-base-value': se_component.compare_base && se_component.quantity !== se_component.compare_base.quantity,
+			}">
 			<select
 				v-if="quantity_configurable"
 				class="quantity-column-select"
@@ -11,16 +15,29 @@
 				:class="{ 'has-error': has_quantity_error }">
 
 				<option v-if="!valid_quantities.includes(quantity)">{{quantity}}</option>
-				<option v-for="valid_quantity in valid_quantities" :key="valid_quantity">{{valid_quantity}}</option>
+				<option
+					v-for="valid_quantity in valid_quantities"
+					:key="valid_quantity"
+					:class="{ 'compare-base-value': se_component.compare_base && valid_quantity === se_component.compare_base.quantity }">
+					{{valid_quantity}}
+				</option>
 			</select>
 			<span v-if="!quantity_configurable">{{quantity_pretty}}</span>
 		</td>
 
-		<td class="part-column">
+		<td :class="{
+				'part-column': true,
+				'compare-base-value': se_component.compare_base && se_component.part !== se_component.compare_base.part,
+			}">
 			<select
 				v-model="part"
 				class="part-column-select">
-				<option v-for="part_value in valid_parts" :key="part_value['Name']">{{part_value['Name']}}</option>
+				<option
+					v-for="part_value in valid_parts"
+					:key="part_value['Name']"
+					:class="{ 'compare-base-value': se_component.compare_base && part_value['Name'] === se_component.compare_base.part }">
+					{{part_value['Name']}}
+				</option>
 				<option v-if="!is_valid_part" class="has-error">{{part}}</option>
 			</select>
 		</td>
@@ -32,8 +49,13 @@
 		<td class="weight-internal-column">{{weight_internal}}</td>
 		<td class="weight-external-column">{{weight_external}}</td>
 
-		<td class="br-column">{{cost_br}}</td>
-		<td class="sr-column">{{cost_sr}}</td>
+		<td class="br-column">{{cost_BR}}</td>
+		<td class="sr-column">{{cost_SR}}</td>
+
+		<template v-if="se_component.refit_valid">
+			<td class="br-column">{{refit_cost_BR}}</td>
+			<td class="sr-column">{{refit_cost_SR}}</td>
+		</template>
 
 		<td class="power-cost-column">{{power_cost}}</td>
 		<td class="power-gen-column">{{power_gen}}</td>
@@ -96,11 +118,17 @@ export default {
 		power_cost() {
 			return pretty(this.se_component.cost_power);
 		},
-		cost_sr() {
+		cost_BR() {
+			return pretty(this.se_component.cost_BR);
+		},
+		cost_SR() {
 			return pretty(this.se_component.cost_SR);
 		},
-		cost_br() {
-			return pretty(this.se_component.cost_BR);
+		refit_cost_BR() {
+			return pretty(this.se_component.refit_cost_BR);
+		},
+		refit_cost_SR() {
+			return pretty(this.se_component.refit_cost_SR);
 		},
 		weight_internal() {
 			return pretty(this.se_component.weight_internal);
@@ -198,6 +226,10 @@ export default {
 .component-tr {
 	width: 100%;
 	margin: 0px;
+}
+
+.compare-base-value {
+	background: #ffff00;
 }
 
 .has-error {

--- a/src/components/shipdesigner/design-summary.vue
+++ b/src/components/shipdesigner/design-summary.vue
@@ -16,6 +16,11 @@
 			<span> | </span>
 			<span>[{{se_design.cost_BR_raw.toFixed(2)}}]br</span>
 			<span>[{{se_design.cost_SR_raw.toFixed(2)}}]sr</span>
+			<template v-if="se_design.refit_valid">
+				<span> | Refit </span>
+				<span>[{{se_design.refit_cost_BR_raw.toFixed(2)}}]br</span>
+				<span>[{{se_design.refit_cost_SR_raw.toFixed(2)}}]sr</span>
+			</template>
 			<span> | </span>
 			<span>{{se_design.cost_crew_raw.toFixed(2)}}</span>
 			<span> | </span>
@@ -24,17 +29,17 @@
 		<div>
 			<span
 				class="design-power-summary"
-				:class="{'has-error': se_design.cost_power_raw > se_design.power_generation_raw}"
+				:class="{'has-error': !se_design.compare_base && se_design.cost_power_raw > se_design.power_generation_raw}"
 				>Power[{{se_design.cost_power_raw.toFixed(2)}}/{{se_design.power_generation_raw.toFixed(2)}}]</span>
 			<span
 				class="design-weight-summary"
-				:class="{'has-error': se_design.weight_internal > se_design.frame_max_size_raw}"
+				:class="{'has-error': !se_design.compare_base && se_design.weight_internal > se_design.frame_max_size_raw}"
 				>Internal[{{se_design.weight_internal.toFixed(2)}}/{{se_design.frame_max_size_raw.toFixed(2)}}]</span>
 			<span
 				class="subsystem-weight-summary"
 				v-for="ss in se_design.subsystems"
 				:key="ss.name"
-				:class="{'has-error': ss.weight_internal > ss.weight_cap}"
+				:class="{'has-error': !ss.compare_base && ss.weight_internal > ss.weight_cap}"
 				>{{ss.name}}[{{ss.weight_internal.toFixed(2)}}/{{ss.weight_cap.toFixed(2)}}] </span>
 		</div>
 	</div>

--- a/src/components/shipdesigner/design-summary.vue
+++ b/src/components/shipdesigner/design-summary.vue
@@ -29,17 +29,17 @@
 		<div>
 			<span
 				class="design-power-summary"
-				:class="{'has-error': !se_design.compare_base && se_design.cost_power_raw > se_design.power_generation_raw}"
+				:class="{'has-error': !se_design.omit_validation && se_design.cost_power_raw > se_design.power_generation_raw}"
 				>Power[{{se_design.cost_power_raw.toFixed(2)}}/{{se_design.power_generation_raw.toFixed(2)}}]</span>
 			<span
 				class="design-weight-summary"
-				:class="{'has-error': !se_design.compare_base && se_design.weight_internal > se_design.frame_max_size_raw}"
+				:class="{'has-error': !se_design.omit_validation && se_design.weight_internal > se_design.frame_max_size_raw}"
 				>Internal[{{se_design.weight_internal.toFixed(2)}}/{{se_design.frame_max_size_raw.toFixed(2)}}]</span>
 			<span
 				class="subsystem-weight-summary"
 				v-for="ss in se_design.subsystems"
 				:key="ss.name"
-				:class="{'has-error': !ss.compare_base && ss.weight_internal > ss.weight_cap}"
+				:class="{'has-error': !ss.omit_validation && ss.weight_internal > ss.weight_cap}"
 				>{{ss.name}}[{{ss.weight_internal.toFixed(2)}}/{{ss.weight_cap.toFixed(2)}}] </span>
 		</div>
 	</div>

--- a/src/components/shipdesigner/design.vue
+++ b/src/components/shipdesigner/design.vue
@@ -16,6 +16,10 @@
 					<th>Ext)</th>
 					<th>BR</th>
 					<th>SR</th>
+					<template v-if="se_design.refit_valid">
+						<th>Refit BR</th>
+						<th>Refit SR</th>
+					</template>
 					<th>Pwr Cost</th>
 					<th>Pwr Gen</th>
 					<th>O</th>

--- a/src/components/shipdesigner/module.vue
+++ b/src/components/shipdesigner/module.vue
@@ -164,7 +164,7 @@ export default {
 }
 
 .compare-base-value {
-	background: #ffff00;
+	background: #aa80ff;
 }
 
 .hasloaderror {

--- a/src/components/shipdesigner/module.vue
+++ b/src/components/shipdesigner/module.vue
@@ -2,13 +2,27 @@
 	<tr class="module-tr" :class="{ hasloaderror: !is_loaded }">
 		<td class="name-column" colspan="2">Module</td>
 
-		<td class="part-column">
+		<td :class="{
+				'part-column': true,
+				'compare-base-value': se_module.compare_base &&
+					(se_module.module_type !== se_module.compare_base.module_type || se_module.module_variant !== se_module.compare_base.module_variant),
+			}">
 			<span class="module-pair-span">
 			<span class="module-pair-type"><select v-model="module_type" class="part-column-select">
-				<option v-for="module_type_value in valid_types" :key="module_type_value">{{module_type_value}}</option>
+				<option
+					v-for="module_type_value in valid_types"
+					:key="module_type_value"
+					:class="{ 'compare-base-value': se_module.compare_base && module_type_value === se_module.compare_base.module_type }">
+					{{module_type_value}}
+				</option>
 			</select></span>
 			<span class="module-pair-variant"><select v-model="module_variant" class="part-column-select">
-				<option v-for="module_variant_value in valid_variants" :key="module_variant_value['Variant']">{{module_variant_value['Variant']}}</option>
+				<option
+					v-for="module_variant_value in valid_variants"
+					:key="module_variant_value['Variant']"
+					:class="{ 'compare-base-value': se_module.compare_base && module_variant_value['Variant'] === se_module.compare_base.module_variant }">
+					{{module_variant_value['Variant']}}
+				</option>
 			</select></span>
 			</span>
 		</td>
@@ -20,8 +34,13 @@
 		<td class="weight-internal-column">{{weight_internal}}</td>
 		<td class="weight-external-column">{{weight_external}}</td>
 
-		<td class="br-column">{{cost_br}}</td>
-		<td class="sr-column">{{cost_sr}}</td>
+		<td class="br-column">{{cost_BR}}</td>
+		<td class="sr-column">{{cost_SR}}</td>
+
+		<template v-if="se_module.refit_valid">
+			<td class="br-column">{{refit_cost_BR}}</td>
+			<td class="sr-column">{{refit_cost_SR}}</td>
+		</template>
 
 		<td class="power-cost-column">{{power_cost}}</td>
 		<td class="power-gen-column">{{power_gen}}</td>
@@ -64,11 +83,17 @@ export default {
 		power_cost() {
 			return pretty(this.se_module.cost_power);
 		},
-		cost_sr() {
+		cost_BR() {
+			return pretty(this.se_module.cost_BR);
+		},
+		cost_SR() {
 			return pretty(this.se_module.cost_SR);
 		},
-		cost_br() {
-			return pretty(this.se_module.cost_BR);
+		refit_cost_BR() {
+			return pretty(this.se_module.refit_cost_BR);
+		},
+		refit_cost_SR() {
+			return pretty(this.se_module.refit_cost_SR);
 		},
 		weight_internal() {
 			return pretty(this.se_module.weight_internal);
@@ -136,6 +161,10 @@ export default {
 	background: #ccc;
 
 	width: 100%;
+}
+
+.compare-base-value {
+	background: #ffff00;
 }
 
 .hasloaderror {

--- a/src/components/shipdesigner/principal-frame-final.vue
+++ b/src/components/shipdesigner/principal-frame-final.vue
@@ -15,6 +15,11 @@
 		<td class="br-column">{{se_design.cost_BR}}</td>
 		<td class="sr-column">{{se_design.cost_SR}}</td>
 
+		<template v-if="se_design.refit_valid">
+			<td class="br-column">{{se_design.refit_cost_BR}}</td>
+			<td class="sr-column">{{se_design.refit_cost_SR}}</td>
+		</template>
+
 		<td class="power-cost-column"
 			:title="power_final_title"
 			:class="power_final_class">{{se_design.cost_power}}</td>
@@ -60,26 +65,26 @@ export default {
 			};
 		},
 		has_power_error() {
-			return this.$store.getters.se_design.cost_power_raw > this.$store.getters.se_design.power_generation_raw;
+			return !this.se_design.compare_base && this.se_design.cost_power_raw > this.se_design.power_generation_raw;
 		},
 		principal_frame() {
-			return this.$store.getters.se_design.json['Principal Frame'];
+			return this.se_design.principal_frame;
 		},
 		stats() {
-			return this.$store.getters.se_design.stats;
+			return this.se_design.stats;
 		},
 		crew() {
-			return this.$store.getters.se_design.cost_crew;
+			return this.se_design.cost_crew;
 		},
 		build_time() {
-			return frac(this.$store.getters.se_design.build_time, 12, true);
+			return frac(this.se_design.build_time, 12, true);
 		},
 		tech_year() {
-			return this.$store.getters.se_design.tech_year_max;
+			return this.se_design.tech_year_max;
 		},
 		ship_name: {
 			get() {
-				return this.$store.getters.se_design.json['Name'];
+				return this.se_design.json['Name'];
 			},
 			set(value) {
 				this.$store.commit('set_design_name', value);

--- a/src/components/shipdesigner/principal-frame-final.vue
+++ b/src/components/shipdesigner/principal-frame-final.vue
@@ -65,7 +65,7 @@ export default {
 			};
 		},
 		has_power_error() {
-			return !this.se_design.compare_base && this.se_design.cost_power_raw > this.se_design.power_generation_raw;
+			return !this.se_design.omit_validation && this.se_design.cost_power_raw > this.se_design.power_generation_raw;
 		},
 		principal_frame() {
 			return this.se_design.principal_frame;

--- a/src/components/shipdesigner/principal-frame-raw.vue
+++ b/src/components/shipdesigner/principal-frame-raw.vue
@@ -2,12 +2,21 @@
 	<tr class="principal-frame-raw" v-bind:class="{ 'has-error': !is_valid_frame }">
 		<td class="name-column" colspan="2">Size: {{frame_size}}</td>
 
-		<td class="part-column">
+		<td v-if="!se_design.refit_valid" :class="{
+				'part-column': true,
+				'compare-base-value': se_design.compare_base && se_design.principal_frame !== se_design.compare_base.principal_frame,
+			}">
 			<select v-model="principal_frame" class="part-column-select">
-				<option v-for="princ_frame_value in se_design.valid_frames" :key="princ_frame_value['Name']">{{princ_frame_value['Name']}}</option>
+				<option
+					v-for="princ_frame_value in se_design.valid_frames"
+					:key="princ_frame_value['Name']"
+					:class="{ 'compare-base-value': se_design.compare_base && princ_frame_value['Name'] === se_design.compare_base.principal_frame }">
+					{{princ_frame_value['Name']}}
+				</option>
 				<option v-if="!is_valid_frame" class="has-error">{{principal_frame}}</option>
 			</select>
 		</td>
+		<td v-else>{{principal_frame}}</td>
 
 		<template v-for="name in stats_raw.names">
 			<StatlineCell :key="name" :stats="stats_raw" :name="name"></StatlineCell>
@@ -18,6 +27,11 @@
 
 		<td class="br-column">{{se_design.cost_BR_raw.toFixed(2)}}</td>
 		<td class="sr-column">{{se_design.cost_SR_raw.toFixed(2)}}</td>
+
+		<template v-if="se_design.refit_valid">
+			<td class="br-column">{{se_design.refit_cost_BR_raw.toFixed(2)}}</td>
+			<td class="sr-column">{{se_design.refit_cost_SR_raw.toFixed(2)}}</td>
+		</template>
 
 		<td class="power-cost-column" :title="power_final_title" :class="power_final_class">{{se_design.cost_power_raw.toFixed(2)}}</td>
 		<td class="power-gen-column" :title="power_final_title" :class="power_final_class">{{se_design.power_generation_raw.toFixed(2)}}</td>
@@ -63,7 +77,7 @@ export default {
 			};
 		},
 		has_power_error() {
-			return this.$store.getters.se_design.cost_power_raw > this.$store.getters.se_design.power_generation_raw;
+			return !this.se_design.compare_base && this.se_design.cost_power_raw > this.se_design.power_generation_raw;
 		},
 		weight_summary_class() {
 			return {
@@ -71,30 +85,30 @@ export default {
 			};
 		},
 		has_weight_error() {
-			return this.$store.getters.se_design.weight_internal > this.$store.getters.se_design.frame_max_size_raw;
+			return !this.se_design.compare_base && this.se_design.weight_internal > this.se_design.frame_max_size_raw;
 		},
 		principal_frame: {
 			get() {
-				return this.$store.getters.se_design.json['Principal Frame'];
+				return this.se_design.principal_frame;
 			},
 			set(value) {
-				this.$store.getters.se_design.json['Principal Frame'] = value;
+				this.se_design.principal_frame = value;
 			},
 		},
 		stats_raw() {
-			return this.$store.getters.se_design.stats_raw;
+			return this.se_design.stats_raw;
 		},
 		crew_raw() {
-			return this.$store.getters.se_design.cost_crew_raw;
+			return this.se_design.cost_crew_raw;
 		},
 		build_time_frame() {
-			return frac(this.$store.getters.se_design.build_time_frame, 12);
+			return frac(this.se_design.build_time_frame, 12);
 		},
 		tech_year_frame() {
-			return this.$store.getters.se_design.tech_year_frame;
+			return this.se_design.tech_year_frame;
 		},
 		frame_size() {
-			return this.$store.getters.se_design.frame_size.toFixed(2);
+			return this.se_design.frame_size.toFixed(2);
 		},
 		...mapGetters([
 			'se_design',
@@ -154,6 +168,10 @@ export default {
 
 .power-cost-column {
 	text-align: center;
+}
+
+.compare-base-value {
+	background: #ffff00;
 }
 
 .has-error {

--- a/src/components/shipdesigner/principal-frame-raw.vue
+++ b/src/components/shipdesigner/principal-frame-raw.vue
@@ -77,7 +77,7 @@ export default {
 			};
 		},
 		has_power_error() {
-			return !this.se_design.compare_base && this.se_design.cost_power_raw > this.se_design.power_generation_raw;
+			return !this.se_design.omit_validation && this.se_design.cost_power_raw > this.se_design.power_generation_raw;
 		},
 		weight_summary_class() {
 			return {
@@ -85,7 +85,7 @@ export default {
 			};
 		},
 		has_weight_error() {
-			return !this.se_design.compare_base && this.se_design.weight_internal > this.se_design.frame_max_size_raw;
+			return !this.se_design.omit_validation && this.se_design.weight_internal > this.se_design.frame_max_size_raw;
 		},
 		principal_frame: {
 			get() {

--- a/src/components/shipdesigner/principal-frame-raw.vue
+++ b/src/components/shipdesigner/principal-frame-raw.vue
@@ -171,7 +171,7 @@ export default {
 }
 
 .compare-base-value {
-	background: #ffff00;
+	background: #aa80ff;
 }
 
 .has-error {

--- a/src/components/shipdesigner/setting-cell.vue
+++ b/src/components/shipdesigner/setting-cell.vue
@@ -78,7 +78,7 @@ export default {
 }
 
 .compare-base-value {
-	background: #ffff00;
+	background: #aa80ff;
 }
 
 </style>

--- a/src/components/shipdesigner/setting-cell.vue
+++ b/src/components/shipdesigner/setting-cell.vue
@@ -1,5 +1,8 @@
 <template>
-	<span class="setting-cell">
+	<span :class="{
+			'setting-cell': true,
+			'compare-base-value': setting.compare_base && setting['Value'] !== setting.compare_base['Value'],
+		}">
 		<span class="setting-name">{{setting_name}}</span>
 
 		<select
@@ -7,7 +10,10 @@
 			class="setting-input-number"
 			type="number"
 			v-model="setting_value">
-			<option v-for="num in valid_numbers" :key="num">{{num}}</option>
+			<option
+				v-for="num in valid_numbers"
+				:key="num"
+				:class="{ 'compare-base-value': setting.compare_base && num === setting.compare_base['Value'] }">{{num}}</option>
 		</select>
 
 		<input
@@ -31,13 +37,8 @@ export default {
 		valid_numbers() {
 			return [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5];
 		},
-		setting_name: {
-			get() {
-				return this.setting['Name'];
-			},
-			set(value) {
-				this.setting['Name'] = value;
-			},
+		setting_name() {
+			return this.setting['Name'];
 		},
 		setting_value: {
 			get() {
@@ -74,6 +75,10 @@ export default {
 }
 
 .setting-name {
+}
+
+.compare-base-value {
+	background: #ffff00;
 }
 
 </style>

--- a/src/components/shipdesigner/subsystem-frame.vue
+++ b/src/components/shipdesigner/subsystem-frame.vue
@@ -119,7 +119,7 @@ export default {
 }
 
 .compare-base-value {
-	background: #ffff00;
+	background: #aa80ff;
 }
 
 .has-error {

--- a/src/components/shipdesigner/subsystem-frame.vue
+++ b/src/components/shipdesigner/subsystem-frame.vue
@@ -3,12 +3,21 @@
 	<tr class="subsystem-frame" v-bind:class="{ 'has-error': !is_valid_frame }">
 		<td class="name-column" colspan="2">{{se_subsystem.name}}</td>
 
-		<td class="part-column">
+		<td v-if="!se_subsystem.refit_valid" :class="{
+				'part-column': true,
+				'compare-base-value': se_subsystem.compare_base && se_subsystem.sub_frame !== se_subsystem.compare_base.sub_frame,
+			}">
 			<select v-model="sub_frame" class="part-column-select">
-				<option v-for="sub_frame_value in se_subsystem.valid_frames" :key="sub_frame_value['Name']">{{sub_frame_value['Name']}}</option>
+				<option
+					v-for="sub_frame_value in se_subsystem.valid_frames"
+					:key="sub_frame_value['Name']"
+					:class="{ 'compare-base-value': se_subsystem.compare_base && sub_frame_value['Name'] === se_subsystem.compare_base.sub_frame }">
+					{{sub_frame_value['Name']}}
+				</option>
 				<option v-if="!is_valid_frame" class="has-error">{{sub_frame}}</option>
 			</select>
 		</td>
+		<td v-else>{{sub_frame}}</td>
 
 		<template v-for="name in stats.names">
 			<td :key="name" class="stat-column">{{stats_multiplier_pretty}}</td>
@@ -18,6 +27,11 @@
 
 		<td class="br-column">{{se_subsystem.cost_BR_frame.toFixed(2)}}</td>
 		<td class="sr-column">{{se_subsystem.cost_SR_mult.toFixed(2)}}x</td>
+
+		<template v-if="se_subsystem.refit_valid">
+			<td class="br-column"></td>
+			<td class="sr-column"></td>
+		</template>
 
 		<td class="power-cost-column"></td>
 		<td class="power-gen-column"></td>
@@ -102,6 +116,10 @@ export default {
 <style scoped>
 .subsystem-frame {
 	background: #ccc;
+}
+
+.compare-base-value {
+	background: #ffff00;
 }
 
 .has-error {

--- a/src/components/shipdesigner/subsystem-summary.vue
+++ b/src/components/shipdesigner/subsystem-summary.vue
@@ -58,7 +58,7 @@ export default {
 			};
 		},
 		has_weight_error() {
-			return !this.se_subsystem.compare_base && this.se_subsystem.weight_internal > this.se_subsystem.weight_cap;
+			return !this.se_subsystem.omit_validation && this.se_subsystem.weight_internal > this.se_subsystem.weight_cap;
 		},
 		se_components() {
 			return this.se_subsystem.components;

--- a/src/components/shipdesigner/subsystem-summary.vue
+++ b/src/components/shipdesigner/subsystem-summary.vue
@@ -17,6 +17,11 @@
 		<td class="br-column">{{se_subsystem.cost_BR.toFixed(2)}}</td>
 		<td class="sr-column">{{se_subsystem.cost_SR.toFixed(2)}}</td>
 
+		<template v-if="se_subsystem.refit_valid">
+			<td class="br-column">{{se_subsystem.refit_cost_BR.toFixed(2)}}</td>
+			<td class="sr-column">{{se_subsystem.refit_cost_SR.toFixed(2)}}</td>
+		</template>
+
 		<td class="power-cost-column">{{se_subsystem.cost_power.toFixed(2)}}</td>
 		<td class="power-gen-column">{{se_subsystem.power_generation.toFixed(2)}}</td>
 
@@ -53,7 +58,7 @@ export default {
 			};
 		},
 		has_weight_error() {
-			return this.se_subsystem.weight_internal > this.se_subsystem.weight_cap;
+			return !this.se_subsystem.compare_base && this.se_subsystem.weight_internal > this.se_subsystem.weight_cap;
 		},
 		se_components() {
 			return this.se_subsystem.components;

--- a/src/lib/lang-utils.js
+++ b/src/lib/lang-utils.js
@@ -1,0 +1,12 @@
+import _ from 'lodash';
+
+function zipByAndWith(array1, array2, iteratee, combiner) {
+	let keyValMap1 = new Map(array1.map((x, index, array) => [iteratee(x, index, array), x])); // similar to _.keyBy except iteratee accepts all args passed to .map's callback
+	let keyValMap2 = new Map(array2.map((x, index, array) => [iteratee(x, index, array), x]));
+	let keys = _.union(array1.map(iteratee), array2.map(iteratee));
+	return _.zipWith(keys.map(key => keyValMap1.get(key)), keys.map(key => keyValMap2.get(key)), combiner);
+}
+
+export {
+	zipByAndWith,
+};

--- a/src/lib/shipengine.js
+++ b/src/lib/shipengine.js
@@ -942,6 +942,7 @@ class DesignComponent {
 		[comp, comp_base] = DesignComponent.defaults(comp, comp_base);
 
 		let compare_extensions = {
+			omit_validation: true,
 			compare_base: comp_base,
 
 			// Don't do compare logic on quantity
@@ -1345,6 +1346,7 @@ class DesignSubsystem {
 			});
 
 		let compare_extensions = {
+			omit_validation: true,
 			compare_base: subsystem_base,
 			components,
 			settings,
@@ -1532,6 +1534,7 @@ class Module {
 
 	static compare(module, module_base) {
 		let compare_extensions = {
+			omit_validation: true,
 			compare_base: module_base,
 		};
 
@@ -2098,6 +2101,7 @@ class Design {
 		let module = Module.compare(design.module, design_base.module);
 
 		let compare_extensions = {
+			omit_validation: true,
 			compare_base: design_base,
 			subsystems,
 			module,

--- a/src/lib/shipengine.js
+++ b/src/lib/shipengine.js
@@ -1,4 +1,5 @@
 import { from_frac } from '@/lib/ui-functions.js';
+import { zipByAndWith } from '@/lib/lang-utils.js';
 import { NamedVector } from '@/lib/namedvector.js';
 import _ from 'lodash';
 
@@ -27,6 +28,10 @@ const SR_COST_ROUND_MAP = {
 	'Cruiser': 5,
 	'Explorer': 10,
 };
+
+const REFIT_BR_COST_ROUND = 5;
+
+const REFIT_SR_COST_ROUND = 5;
 
 // =IF(DK$18 = 1, "Frigate", IF(DK$18 = 2, "Cruiser", "Explorer"))
 const WEIGHT_CLASS_MAP = {
@@ -876,6 +881,88 @@ class DesignComponent {
 			return 1.0;
 		}
 	}
+
+	static defaults(comp1, comp2) {
+		if (!comp1 || !comp2) {
+			let comp = comp1 || comp2;
+			let default_comp = new DesignComponent(comp.db, comp.subsystem, {
+				'Name': comp.name,
+			});
+			return [comp1 || default_comp, comp2 || default_comp];
+		} else {
+			return [comp1, comp2];
+		}
+	}
+
+	static refit(comp, comp_base, refit_valid) {
+		[comp, comp_base] = DesignComponent.defaults(comp, comp_base);
+
+		function refit_cost(cost_prop) {
+			let cost = comp[cost_prop];
+			let base_cost = comp_base[cost_prop];
+			if (comp.part === comp_base.part) {
+				if (cost >= base_cost) {
+					return cost - base_cost;
+				} else {
+					return (cost - base_cost) / 2;
+				}
+			} else {
+				return cost - base_cost / 2;
+			}
+		}
+
+		let refit_extensions = {
+			refit_valid,
+			compare_base: comp_base,
+
+			get refit_cost_BR() {
+				return refit_cost('cost_BR');
+			},
+
+			get refit_cost_SR() {
+				return refit_cost('cost_SR');
+			},
+		};
+
+		return new Proxy(refit_extensions, {
+			get(target, prop) {
+				if (prop in target && prop !== 'constructor') {
+					return target[prop];
+				}
+				return comp[prop];
+			},
+
+			set(target, prop, value) {
+				return Reflect.set(comp, prop, value);
+			},
+		});
+	}
+
+	static compare(comp, comp_base) {
+		[comp, comp_base] = DesignComponent.defaults(comp, comp_base);
+
+		let compare_extensions = {
+			compare_base: comp_base,
+
+			// Don't do compare logic on quantity
+			get quantity() {
+				return comp.quantity;
+			},
+		};
+
+		return new Proxy(compare_extensions, {
+			get(target, prop) {
+				if (prop in target && prop !== 'constructor') {
+					return target[prop];
+				}
+				return Design.generic_base_compare(comp[prop], comp_base[prop]);
+			},
+
+			set(target, prop, value) {
+				return Reflect.set(comp, prop, value);
+			},
+		});
+	}
 }
 
 class DesignSubsystem {
@@ -1182,6 +1269,100 @@ class DesignSubsystem {
 		// if frame, then look up "tac mod" field in frames list
 		return this.frame_attribute(SUBSYSTEM_NAME_MAP[this.name]);
 	}
+
+	static defaults(subsystem1, subsystem2) {
+		if (!subsystem1 || !subsystem2) {
+			let subsystem = subsystem1 || subsystem2;
+			let default_subsystem = new DesignSubsystem(subsystem.db, subsystem.design, {
+				'Name': subsystem.name,
+				'Settings': subsystem.settings.map(setting => ({'Name': setting['Name']})),
+				'Components': subsystem.components.map(comp => DesignComponent.defaults(null, comp)[0]),
+			});
+			return [subsystem1 || default_subsystem, subsystem2 || default_subsystem];
+		} else {
+			return [subsystem1, subsystem2];
+		}
+	}
+
+	static refit(subsystem, subsystem_base, refit_valid) {
+		[subsystem, subsystem_base] = DesignSubsystem.defaults(subsystem, subsystem_base);
+		// don't assume order or existence of each component
+		let components = zipByAndWith(subsystem.components, subsystem_base.components, comp => comp.name,
+			(comp, comp_base) => DesignComponent.refit(comp, comp_base, refit_valid));
+		// also don't assume order or existence of each setting
+		let settings = zipByAndWith(subsystem.settings, subsystem_base.settings, setting => setting['Name'],
+			(setting, setting_base) => {
+				setting.compare_base = setting_base;
+				return setting;
+			});
+
+		function refit_cost(cost_prop) {
+			return components
+				.filter(comp => comp.is_loaded)
+				.map(comp => comp['refit_' + cost_prop])
+				.reduce((sum, value) => sum + value, 0);
+		}
+
+		let refit_extensions = {
+			refit_valid,
+			compare_base: subsystem_base,
+			components,
+			settings,
+
+			get refit_cost_BR() {
+				return refit_cost('cost_BR');
+			},
+
+			get refit_cost_SR() {
+				return refit_cost('cost_SR');
+			},
+		};
+
+		return new Proxy(refit_extensions, {
+			get(target, prop) {
+				if (prop in target && prop !== 'constructor') {
+					return target[prop];
+				}
+				return subsystem[prop];
+			},
+
+			set(target, prop, value) {
+				return Reflect.set(subsystem, prop, value);
+			},
+		});
+	}
+
+	static compare(subsystem, subsystem_base) {
+		[subsystem, subsystem_base] = DesignSubsystem.defaults(subsystem, subsystem_base);
+		// don't assume order or existence of each component
+		let components = zipByAndWith(subsystem.components, subsystem_base.components, comp => comp.name,
+			(comp, comp_base) => DesignComponent.compare(comp, comp_base));
+		// also don't assume order or existence of each setting
+		let settings = zipByAndWith(subsystem.settings, subsystem_base.settings, setting => setting['Name'],
+			(setting, setting_base) => {
+				setting.compare_base = setting_base;
+				return setting;
+			});
+
+		let compare_extensions = {
+			compare_base: subsystem_base,
+			components,
+			settings,
+		};
+
+		return new Proxy(compare_extensions, {
+			get(target, prop) {
+				if (prop in target && prop !== 'constructor') {
+					return target[prop];
+				}
+				return Design.generic_base_compare(subsystem[prop], subsystem_base[prop]);
+			},
+
+			set(target, prop, value) {
+				return Reflect.set(subsystem, prop, value);
+			},
+		});
+	}
 }
 
 class Module {
@@ -1313,6 +1494,60 @@ class Module {
 		// $CV88 = DL88 = module weight cap? = module weight cap from "Weight Cap" element of module
 		return this.attribute('Weight Cap');
 	}
+
+	static refit(module, module_base, refit_valid) {
+		function refit_cost(cost_prop) {
+			if (module.module_type === module_base.module_type && module.module_variant === module_base.module_variant) {
+				return 0;
+			}
+			return module[cost_prop] - module_base[cost_prop] / 2;
+		}
+
+		let refit_extensions = {
+			refit_valid,
+			compare_base: module_base,
+
+			get refit_cost_BR() {
+				return refit_cost('cost_BR');
+			},
+
+			get refit_cost_SR() {
+				return refit_cost('cost_SR');
+			},
+		};
+
+		return new Proxy(refit_extensions, {
+			get(target, prop) {
+				if (prop in target && prop !== 'constructor') {
+					return target[prop];
+				}
+				return module[prop];
+			},
+
+			set(target, prop, value) {
+				return Reflect.set(module, prop, value);
+			},
+		});
+	}
+
+	static compare(module, module_base) {
+		let compare_extensions = {
+			compare_base: module_base,
+		};
+
+		return new Proxy(compare_extensions, {
+			get(target, prop) {
+				if (prop in target && prop !== 'constructor') {
+					return target[prop];
+				}
+				return Design.generic_base_compare(module[prop], module_base[prop]);
+			},
+
+			set(target, prop, value) {
+				return Reflect.set(module, prop, value);
+			},
+		});
+	}
 }
 
 
@@ -1379,6 +1614,10 @@ class Design {
 		return this.is_valid_frame && this.subsystems.every(ss => ss.is_loaded) && this.module.is_loaded;
 	}
 
+	get frame_name_map() {
+		return _.fromPairs([['Principal', this.json['Principal Frame']], ...this.json['Subsystems'].map(ss_json => [ss_json['Name'], ss_json['Sub-Frame']])]);
+	}
+
 	get pretty_name() {
 		return this.name
 			+ ' (' + this.timestamp.toLocaleString() + ')'
@@ -1399,6 +1638,14 @@ class Design {
 
 	get parts_list_pretty_name() {
 		return this.parts_list_name + ' (' + this.parts_list_timestamp.toLocaleString() + ')';
+	}
+
+	get principal_frame() {
+		return this.json['Principal Frame'];
+	}
+
+	set principal_frame(value) {
+		this.json['Principal Frame'] = value;
 	}
 
 	get tech_year_frame() {
@@ -1786,6 +2033,116 @@ class Design {
 	}
 
 	get pretty_dump() {
+	}
+
+	static refit_valid(design, design_base) {
+		return _.isEqual(design.frame_name_map, design_base.frame_name_map);
+	}
+
+	static refit(design, design_base) {
+		let refit_valid = Design.refit_valid(design, design_base);
+		// don't assume existence of each subsystem
+		let subsystems = zipByAndWith(design.subsystems, design_base.subsystems, ss => ss.name,
+			(ss, ss_base) => DesignSubsystem.refit(ss, ss_base, refit_valid));
+		let module = Module.refit(design.module, design_base.module, refit_valid);
+
+		function refit_cost(cost_prop) {
+			const ss_cost = subsystems
+				.filter(ss => ss.is_loaded)
+				.map(ss => ss['refit_' + cost_prop])
+				.reduce((sum, value) => sum + value, 0);
+			return ss_cost + module['refit_' + cost_prop];
+		}
+
+		let refit_extensions = {
+			refit_valid,
+			compare_base: design_base,
+			subsystems,
+			module,
+
+			get refit_cost_BR() {
+				return Math.ceil(this.refit_cost_BR_raw / REFIT_BR_COST_ROUND) * REFIT_BR_COST_ROUND;
+			},
+
+			get refit_cost_BR_raw() {
+				return refit_cost('cost_BR');
+			},
+
+			get refit_cost_SR() {
+				return Math.ceil(this.refit_cost_SR_raw / REFIT_SR_COST_ROUND) * REFIT_SR_COST_ROUND;
+			},
+
+			get refit_cost_SR_raw() {
+				return refit_cost('cost_SR');
+			},
+		};
+
+		return new Proxy(refit_extensions, {
+			get(target, prop) {
+				if (prop in target && prop !== 'constructor') {
+					return target[prop];
+				}
+				return design[prop];
+			},
+
+			set(target, prop, value) {
+				return Reflect.set(design, prop, value);
+			},
+		});
+	}
+
+	static compare(design, design_base) {
+		// don't assume existence of each subsystem
+		let subsystems = zipByAndWith(design.subsystems, design_base.subsystems, ss => ss.name,
+			(ss, ss_base) => DesignSubsystem.compare(ss, ss_base));
+		let module = Module.compare(design.module, design_base.module);
+
+		let compare_extensions = {
+			compare_base: design_base,
+			subsystems,
+			module,
+		};
+
+		return new Proxy(compare_extensions, {
+			get(target, prop) {
+				if (prop in target && prop !== 'constructor') {
+					return target[prop];
+				}
+				return Design.generic_base_compare(design[prop], design_base[prop]);
+			},
+
+			set(target, prop, value) {
+				return Reflect.set(design, prop, value);
+			},
+		});
+	}
+
+	static generic_base_compare(v1, v2) {
+		if (v1 === undefined && v2 === undefined) {
+			return undefined;
+		}
+		if (_.isNil(v1) && _.isNil(v2)) {
+			return null;
+		}
+		if (_.isNil(v1)) {
+			if (_.isNumber(v2)) {
+				return -v2;
+			}
+			if (v2 instanceof NamedVector) {
+				return v2.mult(-1);
+			}
+			return v2;
+		}
+		if (_.isNil(v2)) {
+			return v1;
+		}
+		if (_.isNumber(v1)) {
+			return v1 - v2;
+		}
+		if (v1 instanceof NamedVector) {
+			return v1.op((a, b) => a - b, v2);
+		}
+		return v1;
 	}
 }
 

--- a/src/shipdesigner.js
+++ b/src/shipdesigner.js
@@ -23,8 +23,14 @@ if (hash) {
 const store = new Vuex.Store({
 	state: {
 		design_json,
+		other_design_json: null, // TODO: allow url to include a base design for refits?
+
 		parts_list: canon_parts_list,
 		canon_parts_list,
+
+		design_mode_enabled: false,
+		design_mode: null,
+
 		undo: {
 			current: -1,
 			history: [],
@@ -32,7 +38,17 @@ const store = new Vuex.Store({
 	},
 	getters: {
 		se_design(state, getters) {
-			return new ShipEngine.Design(getters.se_db, state.design_json);
+			let design = new ShipEngine.Design(getters.se_db, state.design_json);
+			if (state.design_mode_enabled && state.other_design_json !== null) {
+				let other_design = new ShipEngine.Design(getters.se_db, state.other_design_json);
+				if (state.design_mode === 'refit') {
+					return ShipEngine.Design.refit(design, other_design);
+				}
+				if (state.design_mode === 'compare') {
+					return ShipEngine.Design.compare(design, other_design);
+				}
+			}
+			return design;
 		},
 		se_db(state, getters) {
 			return new ShipEngine.DB(state.parts_list);
@@ -298,6 +314,17 @@ const store = new Vuex.Store({
 		},
 		set_design_json_redo(state, payload) {
 			state.design_json = payload.new_data;
+		},
+
+		set_other_design_json(state, payload) {
+			state.other_design_json = payload;
+		},
+
+		set_design_mode_enabled(state, payload) {
+			state.design_mode_enabled = payload;
+		},
+		set_design_mode(state, payload) {
+			state.design_mode = payload;
 		},
 	},
 });

--- a/test/lib/lang-utils.spec.js
+++ b/test/lib/lang-utils.spec.js
@@ -1,0 +1,33 @@
+import { zipByAndWith } from '@/lib/lang-utils.js';
+
+import _ from 'lodash';
+import assert from 'assert';
+
+describe('lang-utils', () => {
+	describe('zipByAndWith', () => {
+		it('handles same arrays of numbers with identity iteratee and add combiner', () => {
+			assert.deepStrictEqual(zipByAndWith([5, 6, 7, 8], [5, 6, 7, 8], _.identity, _.add), [10, 12, 14, 16]);
+		});
+		it('handles disjoint arrays of numbers with identity iteratee and add combiner', () => {
+			assert.deepStrictEqual(zipByAndWith([1, 2, 3, 4], [5, 6, 7, 8], _.identity, _.add), [1, 2, 3, 4, 5, 6, 7, 8]);
+		});
+		it('handles intersecting arrays of numbers with identity iteratee and add combiner', () => {
+			assert.deepStrictEqual(zipByAndWith([2, 3, 4, 5], [5, 6, 7, 8], _.identity, _.add), [2, 3, 4, 10, 6, 7, 8]);
+		});
+		it('handles arrays of numbers with even/odd iteratee and add combiner', () => { // note same 'last value' behavior as _.keyBy
+			assert.deepStrictEqual(zipByAndWith([1, 2, 3, 4], [5, 6, 7, 8], x => x % 2, _.add), [10, 12]);
+		});
+		it('handles disjoint arrays of numbers with index iteratee and add combiner', () => {
+			assert.deepStrictEqual(zipByAndWith([1, 2, 3, 4], [5, 6, 7, 8], (x, index) => index, _.add), [6, 8, 10, 12]);
+		});
+		it('handles intersecting arrays of numbers with index iteratee and add combiner', () => {
+			assert.deepStrictEqual(zipByAndWith([2, 3, 4, 5], [5, 6, 7, 8], (x, index) => index, _.add), [7, 9, 11, 13]);
+		});
+		it('handles arrays of numbers with holes in first array with identity iteratee and add combiner', () => {
+			assert.deepStrictEqual(zipByAndWith([5, 7], [5, 6, 7, 8], _.identity, _.add), [10, 14, 6, 8]);
+		});
+		it('handles arrays of numbers with holes in second array with identity iteratee and add combiner', () => {
+			assert.deepStrictEqual(zipByAndWith([5, 6, 7, 8], [5, 7], _.identity, _.add), [10, 6, 14, 8]);
+		});
+	});
+});


### PR DESCRIPTION
Implement refit and compare design modes.
Add lang-utils.js with zipByAndWith function.

Addresses #45.

Apologies for the monolithic commit - I had to do a lot of experimenting, which precluded an organized series of commits. I've tried to keep other incidental changes to the minimum.

Anyway, as you can see, the key implementation detail is that I'm using JS Proxy.